### PR TITLE
[✨FEATURE] Implement User SignUp with Email Certifing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,9 @@ dependencies {
     //json
     implementation 'org.json:json:20230227'
 
+    //mail
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/the_monitor/TheMonitorApplication.java
+++ b/src/main/java/the_monitor/TheMonitorApplication.java
@@ -2,8 +2,10 @@ package the_monitor;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing  // Auditing 기능을 활성화
 public class TheMonitorApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/the_monitor/application/dto/ErrorReasonDto.java
+++ b/src/main/java/the_monitor/application/dto/ErrorReasonDto.java
@@ -1,4 +1,4 @@
-package the_monitor.application;
+package the_monitor.application.dto;
 
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/the_monitor/application/dto/ReasonDto.java
+++ b/src/main/java/the_monitor/application/dto/ReasonDto.java
@@ -1,4 +1,4 @@
-package the_monitor.application;
+package the_monitor.application.dto;
 
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/the_monitor/application/dto/request/AccountCreateRequest.java
+++ b/src/main/java/the_monitor/application/dto/request/AccountCreateRequest.java
@@ -46,7 +46,7 @@ public class AccountCreateRequest {
 
     }
 
-    public Account toEntity() {
+    public Account toEntity(String CertificationKey) {
 
         return Account.builder()
                 .email(email)
@@ -55,7 +55,7 @@ public class AccountCreateRequest {
                 .managerName(managerName)
                 .managerPhone(managerPhone)
                 .agreement(agreement)
-                .emailVerified(false)
+                .emailCertificationKey(CertificationKey)
                 .build();
 
     }

--- a/src/main/java/the_monitor/application/dto/request/AccountCreateRequest.java
+++ b/src/main/java/the_monitor/application/dto/request/AccountCreateRequest.java
@@ -1,0 +1,64 @@
+package the_monitor.application.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import the_monitor.domain.model.Account;
+
+@Getter
+@NoArgsConstructor
+public class AccountCreateRequest {
+
+    @NotBlank(message = "email은 필수입니다.")
+    private String email;
+
+    @NotBlank(message = "password는 필수입니다.")
+    private String password;
+
+    @NotBlank(message = "기업명은 필수입니다.")
+    private String companyName;
+
+    @NotBlank(message = "담당자명은 필수입니다.")
+    private String managerName;
+
+    private String managerPhone;
+
+    @NotNull(message = "이용 약관 및 개인정보 수집 동의는 필수입니다.")
+    private boolean agreement;
+
+    @Builder
+    public AccountCreateRequest(
+            String email,
+            String password,
+            String companyName,
+            String managerName,
+            String managerPhone,
+            boolean agreement) {
+
+        this.email = email;
+        this.password = password;
+        this.companyName = companyName;
+        this.managerName = managerName;
+        this.managerPhone = managerPhone;
+        this.agreement = agreement;
+
+    }
+
+    public Account toEntity() {
+
+        return Account.builder()
+                .email(email)
+                .password(password)
+                .companyName(companyName)
+                .managerName(managerName)
+                .managerPhone(managerPhone)
+                .agreement(agreement)
+                .emailVerified(false)
+                .build();
+
+    }
+
+
+}

--- a/src/main/java/the_monitor/application/service/AccountService.java
+++ b/src/main/java/the_monitor/application/service/AccountService.java
@@ -1,0 +1,12 @@
+package the_monitor.application.service;
+
+import the_monitor.domain.model.Account;
+
+public interface AccountService {
+
+//    void registerUser();
+    Account findAccountById(Long id);
+
+    String createAccount();
+
+}

--- a/src/main/java/the_monitor/application/service/AccountService.java
+++ b/src/main/java/the_monitor/application/service/AccountService.java
@@ -1,7 +1,10 @@
 package the_monitor.application.service;
 
+import jakarta.servlet.http.HttpServletResponse;
 import the_monitor.application.dto.request.AccountCreateRequest;
 import the_monitor.domain.model.Account;
+
+import java.io.IOException;
 
 public interface AccountService {
 
@@ -9,5 +12,7 @@ public interface AccountService {
     Account findAccountById(Long id);
 
     String createAccount(AccountCreateRequest request);
+
+    void verifyEmail(String certifiedKey, HttpServletResponse response) throws IOException;
 
 }

--- a/src/main/java/the_monitor/application/service/AccountService.java
+++ b/src/main/java/the_monitor/application/service/AccountService.java
@@ -1,5 +1,6 @@
 package the_monitor.application.service;
 
+import the_monitor.application.dto.request.AccountCreateRequest;
 import the_monitor.domain.model.Account;
 
 public interface AccountService {
@@ -7,6 +8,6 @@ public interface AccountService {
 //    void registerUser();
     Account findAccountById(Long id);
 
-    String createAccount();
+    String createAccount(AccountCreateRequest request);
 
 }

--- a/src/main/java/the_monitor/application/service/EmailService.java
+++ b/src/main/java/the_monitor/application/service/EmailService.java
@@ -1,0 +1,10 @@
+package the_monitor.application.service;
+
+
+import jakarta.mail.MessagingException;
+
+public interface EmailService {
+
+    void sendEmail(String to, String subject, String text) throws MessagingException;
+
+}

--- a/src/main/java/the_monitor/application/service/EmailService.java
+++ b/src/main/java/the_monitor/application/service/EmailService.java
@@ -3,8 +3,10 @@ package the_monitor.application.service;
 
 import jakarta.mail.MessagingException;
 
+import java.io.UnsupportedEncodingException;
+
 public interface EmailService {
 
-    void sendEmail(String to, String subject, String text) throws MessagingException;
+    void sendEmail(String to, String subject, String text) throws MessagingException, UnsupportedEncodingException;
 
 }

--- a/src/main/java/the_monitor/application/service/UserService.java
+++ b/src/main/java/the_monitor/application/service/UserService.java
@@ -1,9 +1,0 @@
-package the_monitor.application.service;
-
-import the_monitor.domain.model.User;
-
-public interface UserService {
-
-//    void registerUser();
-    User findUserById(Long id);
-}

--- a/src/main/java/the_monitor/application/serviceImpl/AccountServiceImpl.java
+++ b/src/main/java/the_monitor/application/serviceImpl/AccountServiceImpl.java
@@ -28,7 +28,7 @@ public class AccountServiceImpl implements AccountService {
     public String createAccount(AccountCreateRequest request) {
 
         accountRepository.save(request.toEntity());
-        return "계정 생성 완료";
+        return "계정 생성 완료. 이메일 인증을 완료해야 합니다.";
 
     }
 

--- a/src/main/java/the_monitor/application/serviceImpl/AccountServiceImpl.java
+++ b/src/main/java/the_monitor/application/serviceImpl/AccountServiceImpl.java
@@ -3,23 +3,23 @@ package the_monitor.application.serviceImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import the_monitor.application.service.UserService;
+import the_monitor.application.service.AccountService;
 import the_monitor.common.ApiException;
 import the_monitor.common.ErrorStatus;
-import the_monitor.domain.model.User;
-import the_monitor.domain.repository.UserRepository;
+import the_monitor.domain.model.Account;
+import the_monitor.domain.repository.AccountRepository;
 
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
-public class UserServiceImpl implements UserService {
+public class AccountServiceImpl implements AccountService {
 
-    private final UserRepository userRepository;
+    private final AccountRepository accountRepository;
 
     @Override
-    public User findUserById(Long id) {
-        return userRepository.findById(id)
-                .orElseThrow(() -> new ApiException(ErrorStatus._USER_NOT_FOUND));
+    public Account findAccountById(Long id) {
+        return accountRepository.findById(id)
+                .orElseThrow(() -> new ApiException(ErrorStatus._ACCOUNT_NOT_FOUND));
     }
 //    @Override
 //    public void registerUser() {

--- a/src/main/java/the_monitor/application/serviceImpl/AccountServiceImpl.java
+++ b/src/main/java/the_monitor/application/serviceImpl/AccountServiceImpl.java
@@ -10,6 +10,8 @@ import the_monitor.common.ErrorStatus;
 import the_monitor.domain.model.Account;
 import the_monitor.domain.repository.AccountRepository;
 
+import java.util.UUID;
+
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -27,7 +29,7 @@ public class AccountServiceImpl implements AccountService {
     @Transactional
     public String createAccount(AccountCreateRequest request) {
 
-        accountRepository.save(request.toEntity());
+        accountRepository.save(request.toEntity(generateCertifiedKey()));
         return "계정 생성 완료. 이메일 인증을 완료해야 합니다.";
 
     }
@@ -42,5 +44,9 @@ public class AccountServiceImpl implements AccountService {
 //        userRepository.save(user);
 //
 //    }
+
+    private String generateCertifiedKey() {
+        return UUID.randomUUID().toString();  // UUID 생성
+    }
 
 }

--- a/src/main/java/the_monitor/application/serviceImpl/AccountServiceImpl.java
+++ b/src/main/java/the_monitor/application/serviceImpl/AccountServiceImpl.java
@@ -2,6 +2,7 @@ package the_monitor.application.serviceImpl;
 
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import the_monitor.application.dto.request.AccountCreateRequest;
@@ -15,6 +16,7 @@ import the_monitor.domain.repository.AccountRepository;
 import java.io.IOException;
 import java.util.UUID;
 
+@Slf4j
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -35,8 +37,10 @@ public class AccountServiceImpl implements AccountService {
 
         String certifiedKey = generateCertifiedKey();
         accountRepository.save(request.toEntity(certifiedKey));
+        log.info("계정 생성 완료. 이메일 발송 중...");
 
-        String verificationLink = "http://localhost:8080/api/v1/account/verify?certifiedKey=" + certifiedKey;
+        String verificationLink = "http://localhost:8080/api/v1/account/verify?certifiedKey=" + certifiedKey; // 이거 나중에 프론트 URL로 변경 필요
+        // 아래도 마찬가지로 링크 변경 필요.
         String emailContent = "<html>" +
                 "<body>" +
                 "<h1>이메일 인증 요청</h1>" +
@@ -65,22 +69,10 @@ public class AccountServiceImpl implements AccountService {
         account.setEmailVerified();
 
         // 인증 성공 후 리다이렉트할 URL
-        String redirectUrl = "http://localhost:3000/email-verification-success"; // 리다이렉트할 URL
+        String redirectUrl = "http://localhost:3000/email-verification-success"; // 리다이렉트할 URL 이후 수정 필요
         response.sendRedirect(redirectUrl);  // 사용자를 해당 URL로 리다이렉트
 
     }
-
-
-//    @Override
-//    public void registerUser() {
-//
-//        User user = new User();
-//        user.setUsername(signupRequest.getUsername());
-//        user.setEmail(signupRequest.getEmail());
-//        user.setPassword(passwordEncoder.encode(signupRequest.getPassword()));
-//        userRepository.save(user);
-//
-//    }
 
     private String generateCertifiedKey() {
         return UUID.randomUUID().toString();  // UUID 생성

--- a/src/main/java/the_monitor/application/serviceImpl/AccountServiceImpl.java
+++ b/src/main/java/the_monitor/application/serviceImpl/AccountServiceImpl.java
@@ -3,6 +3,7 @@ package the_monitor.application.serviceImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import the_monitor.application.dto.request.AccountCreateRequest;
 import the_monitor.application.service.AccountService;
 import the_monitor.common.ApiException;
 import the_monitor.common.ErrorStatus;
@@ -21,6 +22,16 @@ public class AccountServiceImpl implements AccountService {
         return accountRepository.findById(id)
                 .orElseThrow(() -> new ApiException(ErrorStatus._ACCOUNT_NOT_FOUND));
     }
+
+    @Override
+    @Transactional
+    public String createAccount(AccountCreateRequest request) {
+
+        accountRepository.save(request.toEntity());
+        return "계정 생성 완료";
+
+    }
+
 //    @Override
 //    public void registerUser() {
 //

--- a/src/main/java/the_monitor/application/serviceImpl/AccountServiceImpl.java
+++ b/src/main/java/the_monitor/application/serviceImpl/AccountServiceImpl.java
@@ -1,15 +1,18 @@
 package the_monitor.application.serviceImpl;
 
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import the_monitor.application.dto.request.AccountCreateRequest;
 import the_monitor.application.service.AccountService;
+import the_monitor.application.service.EmailService;
 import the_monitor.common.ApiException;
 import the_monitor.common.ErrorStatus;
 import the_monitor.domain.model.Account;
 import the_monitor.domain.repository.AccountRepository;
 
+import java.io.IOException;
 import java.util.UUID;
 
 @Service
@@ -18,6 +21,7 @@ import java.util.UUID;
 public class AccountServiceImpl implements AccountService {
 
     private final AccountRepository accountRepository;
+    private final EmailService emailService;
 
     @Override
     public Account findAccountById(Long id) {
@@ -29,10 +33,43 @@ public class AccountServiceImpl implements AccountService {
     @Transactional
     public String createAccount(AccountCreateRequest request) {
 
-        accountRepository.save(request.toEntity(generateCertifiedKey()));
-        return "계정 생성 완료. 이메일 인증을 완료해야 합니다.";
+        String certifiedKey = generateCertifiedKey();
+        accountRepository.save(request.toEntity(certifiedKey));
+
+        String verificationLink = "http://localhost:8080/api/v1/account/verify?certifiedKey=" + certifiedKey;
+        String emailContent = "<html>" +
+                "<body>" +
+                "<h1>이메일 인증 요청</h1>" +
+                "<p>회원가입을 완료하려면 아래 버튼을 클릭하여 이메일 인증을 완료해 주세요.</p>" +
+                "<a href=\"" + verificationLink + "\" style=\"display:inline-block;padding:10px 20px;background-color:#4CAF50;color:white;text-decoration:none;border-radius:5px;\">이메일 인증하기</a>" +
+                "<p>위 버튼을 클릭할 수 없다면 아래 링크를 복사하여 브라우저에 붙여넣어 주세요:</p>" +
+                "<p><a href=\"" + verificationLink + "\">" + verificationLink + "</a></p>" +
+                "</body>" +
+                "</html>";
+        try {
+            emailService.sendEmail(request.getEmail(), "The Monitor 회원가입 인증 메일입니다.", emailContent);
+        } catch (Exception e) {
+            throw new ApiException(ErrorStatus._EMAIL_SEND_FAIL);
+        }
+
+        return "계정 생성 완료. 이메일을 발송했습니다. 인증을 완료해주세요.";
 
     }
+
+    @Override
+    public void verifyEmail(String certifiedKey, HttpServletResponse response) throws IOException {
+
+        Account account = accountRepository.findByEmailCertificationKey(certifiedKey);
+        if (account == null) throw new ApiException(ErrorStatus._INVALID_CERTIFIED_KEY);
+
+        account.setEmailVerified();
+
+        // 인증 성공 후 리다이렉트할 URL
+        String redirectUrl = "http://localhost:3000/email-verification-success"; // 리다이렉트할 URL
+        response.sendRedirect(redirectUrl);  // 사용자를 해당 URL로 리다이렉트
+
+    }
+
 
 //    @Override
 //    public void registerUser() {

--- a/src/main/java/the_monitor/application/serviceImpl/EmailServiceImpl.java
+++ b/src/main/java/the_monitor/application/serviceImpl/EmailServiceImpl.java
@@ -9,20 +9,22 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import the_monitor.application.service.EmailService;
 
+import java.io.UnsupportedEncodingException;
+
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class EmailServiceImpl implements EmailService {
 
-    private JavaMailSender javaMailSender;
+    private final JavaMailSender javaMailSender;
 
     @Override
-    public void sendEmail(String toEmail, String subject, String body) throws MessagingException {
+    public void sendEmail(String toEmail, String subject, String body) throws MessagingException, UnsupportedEncodingException {
 
         MimeMessage mimeMessage = javaMailSender.createMimeMessage();
         MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, "utf-8");
 
-        helper.setFrom("The Monitor"); //보내는사람
+        helper.setFrom("themonitor2024@gmail.com","The Monitor"); //보내는사람
         helper.setTo(toEmail); //받는사람
         helper.setSubject(subject); //메일제목
         helper.setText(body, true); //ture넣을경우 html

--- a/src/main/java/the_monitor/application/serviceImpl/EmailServiceImpl.java
+++ b/src/main/java/the_monitor/application/serviceImpl/EmailServiceImpl.java
@@ -1,0 +1,34 @@
+package the_monitor.application.serviceImpl;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import the_monitor.application.service.EmailService;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class EmailServiceImpl implements EmailService {
+
+    private JavaMailSender javaMailSender;
+
+    @Override
+    public void sendEmail(String toEmail, String subject, String body) throws MessagingException {
+
+        MimeMessage mimeMessage = javaMailSender.createMimeMessage();
+        MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, "utf-8");
+
+        helper.setFrom("The Monitor"); //보내는사람
+        helper.setTo(toEmail); //받는사람
+        helper.setSubject(subject); //메일제목
+        helper.setText(body, true); //ture넣을경우 html
+
+        javaMailSender.send(mimeMessage);
+
+    }
+
+}

--- a/src/main/java/the_monitor/common/ApiException.java
+++ b/src/main/java/the_monitor/common/ApiException.java
@@ -1,6 +1,6 @@
 package the_monitor.common;
 
-import the_monitor.application.ErrorReasonDto;
+import the_monitor.application.dto.ErrorReasonDto;
 
 public class ApiException extends RuntimeException{
 

--- a/src/main/java/the_monitor/common/Config/MailConfig.java
+++ b/src/main/java/the_monitor/common/Config/MailConfig.java
@@ -1,0 +1,41 @@
+package the_monitor.common.Config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+@Configuration
+public class MailConfig {
+
+    @Value("${spring.mail.host}")
+    private String host;
+    @Value("${spring.mail.port}")
+    private int port;
+
+    @Value("${spring.mail.username}")
+    private String mailUsername;
+
+    @Value("${spring.mail.password}")
+    private String password;
+
+    @Bean
+    public JavaMailSender javaMailSender() {
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+        mailSender.setHost(host);
+        mailSender.setPort(port);
+        mailSender.setUsername(mailUsername);
+        mailSender.setPassword(password);
+
+        Properties props = mailSender.getJavaMailProperties();
+        props.put("mail.transport.protocol", "smtp");
+        props.put("mail.smtp.auth", "true");
+        props.put("mail.smtp.starttls.enable", "true");
+
+        return mailSender;
+    }
+
+}

--- a/src/main/java/the_monitor/common/ErrorStatus.java
+++ b/src/main/java/the_monitor/common/ErrorStatus.java
@@ -3,7 +3,7 @@ package the_monitor.common;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
-import the_monitor.application.ErrorReasonDto;
+import the_monitor.application.dto.ErrorReasonDto;
 import the_monitor.domain.BaseErrorCode;
 
 @Getter
@@ -11,7 +11,7 @@ import the_monitor.domain.BaseErrorCode;
 public enum ErrorStatus implements BaseErrorCode {
 
     // 일반 응답
-    _USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER404", "해당 유저를 찾을 수 없습니다."),
+    _ACCOUNT_NOT_FOUND(HttpStatus.NOT_FOUND, "ACCOUNT404", "해당 계정을 찾을 수 없습니다."),
     _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러, 관리자에게 문의 바랍니다."),
     _BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON400", "잘못된 요청입니다."),
     _UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON401", "인증되지 않은 요청입니다."),

--- a/src/main/java/the_monitor/common/ErrorStatus.java
+++ b/src/main/java/the_monitor/common/ErrorStatus.java
@@ -22,7 +22,8 @@ public enum ErrorStatus implements BaseErrorCode {
     _JWT_NOT_FOUND(HttpStatus.NOT_FOUND, "JWT404", "토큰을 찾을 수 없습니다"),
     _JWT_INVALID(HttpStatus.UNAUTHORIZED, "JWT400", "유효하지 않는 토큰입니다"),
     _JWT_EXPIRED(HttpStatus.UNAUTHORIZED, "JWT400", "만료된 토큰입니다"),
-    _JWT_BLACKLIST(HttpStatus.UNAUTHORIZED, "JWT400", "접근 불가능한 토큰입니다");
+    _JWT_BLACKLIST(HttpStatus.UNAUTHORIZED, "JWT400", "접근 불가능한 토큰입니다"),
+    _JWT_UNKNOWN(HttpStatus.UNAUTHORIZED, "JWT400", "JWT 인증 중 알 수 없는 오류가 발생했습니다.");
 
 
 

--- a/src/main/java/the_monitor/common/ErrorStatus.java
+++ b/src/main/java/the_monitor/common/ErrorStatus.java
@@ -12,13 +12,13 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // 일반 응답
     _ACCOUNT_NOT_FOUND(HttpStatus.NOT_FOUND, "ACCOUNT404", "해당 계정을 찾을 수 없습니다."),
+    _INVALID_CERTIFIED_KEY(HttpStatus.BAD_REQUEST, "ACCOUNT400", "유효하지 않은 인증키입니다."),
     _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러, 관리자에게 문의 바랍니다."),
     _BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON400", "잘못된 요청입니다."),
     _UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON401", "인증되지 않은 요청입니다."),
     _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "접근 권한이 없습니다."),
     _FILE_DOWNLOAD_FAILED(HttpStatus.BAD_REQUEST, "FILE404", "파일을 다운받을 수 없습니다."),
-    _ADMIN_NOT_FOUND(HttpStatus.NOT_FOUND, "ADMIN404", "해당 관리자를 찾을 수 없습니다."),
-    _ADMIN_NOT_VALID(HttpStatus.UNAUTHORIZED, "ADMIN400", "비밀번호가 일치하지 않습니다"),
+    _EMAIL_SEND_FAIL(HttpStatus.BAD_REQUEST, "EMAIL400", "이메일 전송에 실패했습니다."),
     _JWT_NOT_FOUND(HttpStatus.NOT_FOUND, "JWT404", "토큰을 찾을 수 없습니다"),
     _JWT_INVALID(HttpStatus.UNAUTHORIZED, "JWT400", "유효하지 않는 토큰입니다"),
     _JWT_EXPIRED(HttpStatus.UNAUTHORIZED, "JWT400", "만료된 토큰입니다"),

--- a/src/main/java/the_monitor/common/SuccessStatus.java
+++ b/src/main/java/the_monitor/common/SuccessStatus.java
@@ -3,7 +3,7 @@ package the_monitor.common;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
-import the_monitor.application.ReasonDto;
+import the_monitor.application.dto.ReasonDto;
 import the_monitor.domain.BaseCode;
 
 @Getter

--- a/src/main/java/the_monitor/domain/BaseCode.java
+++ b/src/main/java/the_monitor/domain/BaseCode.java
@@ -1,6 +1,6 @@
 package the_monitor.domain;
 
-import the_monitor.application.ReasonDto;
+import the_monitor.application.dto.ReasonDto;
 
 public interface BaseCode {
 

--- a/src/main/java/the_monitor/domain/BaseErrorCode.java
+++ b/src/main/java/the_monitor/domain/BaseErrorCode.java
@@ -1,6 +1,6 @@
 package the_monitor.domain;
 
-import the_monitor.application.ErrorReasonDto;
+import the_monitor.application.dto.ErrorReasonDto;
 
 public interface BaseErrorCode {
 

--- a/src/main/java/the_monitor/domain/model/Account.java
+++ b/src/main/java/the_monitor/domain/model/Account.java
@@ -9,37 +9,37 @@ import the_monitor.common.BaseTimeEntity;
 @Entity
 @NoArgsConstructor
 @Getter
-@Table(name = "user")
-public class User extends BaseTimeEntity {
+@Table(name = "accounts")
+public class Account extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "user_id")
+    @Column(name = "account_id")
     private Long id;
 
-    @Column(name = "user_email", nullable = false)
+    @Column(name = "account_email", nullable = false)
     private String email;
 
-    @Column(name = "user_password", nullable = false)
+    @Column(name = "account_password", nullable = false)
     private String password;
 
-    @Column(name = "user_company_name")
+    @Column(name = "account_company_name")
     private String companyName;
 
-    @Column(name = "user_manager_name")
+    @Column(name = "account_manager_name")
     private String managerName;
 
-    @Column(name = "user_manager_phone")
+    @Column(name = "account_manager_phone")
     private String managerPhone;
 
-    @Column(name = "user_agreement")
+    @Column(name = "account_agreement")
     private boolean agreement;
 
-    @Column(name = "email_verified", nullable = false)
+    @Column(name = "account_email_verified", nullable = false)
     private boolean emailVerified = false;
 
     @Builder
-    public User(String email, String password, String companyName, String managerName, String managerPhone, boolean agreement, boolean emailVerified) {
+    public Account(String email, String password, String companyName, String managerName, String managerPhone, boolean agreement, boolean emailVerified) {
 
         this.email = email;
         this.password = password;

--- a/src/main/java/the_monitor/domain/model/Account.java
+++ b/src/main/java/the_monitor/domain/model/Account.java
@@ -1,15 +1,16 @@
 package the_monitor.domain.model;
 
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import the_monitor.common.BaseTimeEntity;
 
 @Entity
-@NoArgsConstructor
 @Getter
 @Table(name = "accounts")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Account extends BaseTimeEntity {
 
     @Id
@@ -35,11 +36,14 @@ public class Account extends BaseTimeEntity {
     @Column(name = "account_agreement")
     private boolean agreement;
 
+    @Column(name = "account_email_certification_key")
+    private String emailCertificationKey;
+
     @Column(name = "account_email_verified", nullable = false)
-    private boolean emailVerified;
+    private boolean emailVerified = false;
 
     @Builder
-    public Account(String email, String password, String companyName, String managerName, String managerPhone, boolean agreement, boolean emailVerified) {
+    public Account(String email, String password, String companyName, String managerName, String managerPhone, boolean agreement, String emailCertificationKey) {
 
         this.email = email;
         this.password = password;
@@ -47,8 +51,12 @@ public class Account extends BaseTimeEntity {
         this.managerName = managerName;
         this.managerPhone = managerPhone;
         this.agreement = agreement;
-        this.emailVerified = emailVerified;
+        this.emailCertificationKey = emailCertificationKey;
 
+    }
+
+    public void setEmailVerified() {
+        this.emailVerified = true;
     }
 
 }

--- a/src/main/java/the_monitor/domain/model/Account.java
+++ b/src/main/java/the_monitor/domain/model/Account.java
@@ -36,7 +36,7 @@ public class Account extends BaseTimeEntity {
     private boolean agreement;
 
     @Column(name = "account_email_verified", nullable = false)
-    private boolean emailVerified = false;
+    private boolean emailVerified;
 
     @Builder
     public Account(String email, String password, String companyName, String managerName, String managerPhone, boolean agreement, boolean emailVerified) {

--- a/src/main/java/the_monitor/domain/model/Account.java
+++ b/src/main/java/the_monitor/domain/model/Account.java
@@ -24,16 +24,16 @@ public class Account extends BaseTimeEntity {
     @Column(name = "account_password", nullable = false)
     private String password;
 
-    @Column(name = "account_company_name")
+    @Column(name = "account_company_name", nullable = false)
     private String companyName;
 
-    @Column(name = "account_manager_name")
+    @Column(name = "account_manager_name", nullable = false)
     private String managerName;
 
     @Column(name = "account_manager_phone")
     private String managerPhone;
 
-    @Column(name = "account_agreement")
+    @Column(name = "account_agreement", nullable = false)
     private boolean agreement;
 
     @Column(name = "account_email_certification_key")

--- a/src/main/java/the_monitor/domain/repository/AccountRepository.java
+++ b/src/main/java/the_monitor/domain/repository/AccountRepository.java
@@ -1,6 +1,10 @@
 package the_monitor.domain.repository;
 
+import the_monitor.domain.model.Account;
 import the_monitor.infrastructure.persistence.JpaAccountRepository;
 
 public interface AccountRepository extends JpaAccountRepository {
+
+    Account findByEmailCertificationKey(String certifiedKey);
+
 }

--- a/src/main/java/the_monitor/domain/repository/AccountRepository.java
+++ b/src/main/java/the_monitor/domain/repository/AccountRepository.java
@@ -1,0 +1,6 @@
+package the_monitor.domain.repository;
+
+import the_monitor.infrastructure.persistence.JpaAccountRepository;
+
+public interface AccountRepository extends JpaAccountRepository {
+}

--- a/src/main/java/the_monitor/domain/repository/UserRepository.java
+++ b/src/main/java/the_monitor/domain/repository/UserRepository.java
@@ -1,6 +1,0 @@
-package the_monitor.domain.repository;
-
-import the_monitor.infrastructure.persistence.JpaUserRepository;
-
-public interface UserRepository extends JpaUserRepository {
-}

--- a/src/main/java/the_monitor/infrastructure/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/the_monitor/infrastructure/jwt/JwtAuthenticationEntryPoint.java
@@ -22,6 +22,10 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
         ErrorStatus exception = (ErrorStatus) request.getAttribute("exception");
 
+        if (exception == null) {
+            log.info("No exception found, setting default error");
+            exception = ErrorStatus._JWT_UNKNOWN;  // 기본 예외 상태 설정
+        }
 
         log.info("===================== EntryPoint - Exception Control : " + exception);
 
@@ -32,6 +36,8 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
                 exceptionHandler(response, ErrorStatus._JWT_INVALID, HttpServletResponse.SC_UNAUTHORIZED);
             } else if (exception.equals(ErrorStatus._JWT_EXPIRED)) {
                 exceptionHandler(response, ErrorStatus._JWT_EXPIRED, HttpServletResponse.SC_UNAUTHORIZED);
+            } else {
+                exceptionHandler(response, ErrorStatus._JWT_UNKNOWN, HttpServletResponse.SC_UNAUTHORIZED);
             }
         } catch (JSONException e) {
             throw new RuntimeException(e);

--- a/src/main/java/the_monitor/infrastructure/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/the_monitor/infrastructure/jwt/JwtAuthenticationFilter.java
@@ -88,8 +88,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private boolean isPublicUrl(String requestUrl) {
         return requestUrl.equals("/api") ||
-                requestUrl.equals("/api/login") ||
-                requestUrl.equals("/api/signup") ||
+                requestUrl.equals("/api/v1/accounts") ||
+                requestUrl.equals("/api/v1/accounts/createAccount") ||
+                requestUrl.equals("/api/v1/accounts/verify") ||
                 requestUrl.startsWith("/api/kindergartens/**") ||
                 requestUrl.startsWith("/swagger-ui/**") ||
                 requestUrl.startsWith("/swagger-resources/**") ||

--- a/src/main/java/the_monitor/infrastructure/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/the_monitor/infrastructure/jwt/JwtAuthenticationFilter.java
@@ -11,9 +11,9 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
-import the_monitor.application.service.UserService;
+import the_monitor.application.service.AccountService;
 import the_monitor.common.ErrorStatus;
-import the_monitor.domain.model.User;
+import the_monitor.domain.model.Account;
 
 import java.io.IOException;
 
@@ -23,7 +23,7 @@ import java.io.IOException;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtProvider jwtProvider;
-    private final UserService userService;  // 이메일 인증 확인을 위해 UserService 추가
+    private final AccountService accountService;  // 이메일 인증 확인을 위해 UserService 추가
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
@@ -45,10 +45,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 Authentication authentication = jwtProvider.getAuthentication(accessToken);
 
                 // JWT 토큰에서 사용자 정보 추출 후 이메일 인증 확인
-                Long userId = jwtProvider.getUserId(accessToken);
-                User user = userService.findUserById(userId);  // UserService를 통해 사용자 정보 조회
+                Long accountId = jwtProvider.getAccountId(accessToken);
+                Account account = accountService.findAccountById(accountId);  // UserService를 통해 사용자 정보 조회
 
-                if (!user.isEmailVerified()) {  // 이메일 인증이 안된 경우
+                if (!account.isEmailVerified()) {  // 이메일 인증이 안된 경우
                     log.info("===================== EMAIL NOT VERIFIED");
                     response.sendError(HttpServletResponse.SC_FORBIDDEN, "이메일 인증이 필요합니다.");
                     return;  // 이메일 인증이 안되었으므로 필터 체인을 중단

--- a/src/main/java/the_monitor/infrastructure/jwt/JwtProvider.java
+++ b/src/main/java/the_monitor/infrastructure/jwt/JwtProvider.java
@@ -33,7 +33,7 @@ public class JwtProvider {
     public JwtProvider(@Value("${jwt.secret_key}") String secretKey,
                        @Value("${jwt.access_token_expire}") Long accessTokenExpire,
                        @Value("${jwt.refresh_token_expire}") Long refreshTokenExpire) {
-        this.key = Keys.hmacShaKeyFor(Decoders.BASE64.decode(secretKey));
+        this.key = Keys.secretKeyFor(SignatureAlgorithm.HS256);  // 안전한 256비트 비밀 키 생성
         this.ACCESS_TOKEN_EXPIRE_TIME = accessTokenExpire;
         this.REFRESH_TOKEN_EXPIRE_TIME = refreshTokenExpire;
     }

--- a/src/main/java/the_monitor/infrastructure/jwt/JwtProvider.java
+++ b/src/main/java/the_monitor/infrastructure/jwt/JwtProvider.java
@@ -20,7 +20,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 import the_monitor.common.ApiException;
 import the_monitor.common.ErrorStatus;
-import the_monitor.domain.model.User;
+import the_monitor.domain.model.Account;
 
 @Component
 public class JwtProvider {
@@ -41,23 +41,23 @@ public class JwtProvider {
     /**
      * JWT 토큰 생성 (회원가입 또는 로그인 후 호출)
      */
-    public String generateAccessToken(User user) {
+    public String generateAccessToken(Account account) {
         Date expiredAt = new Date(System.currentTimeMillis() + ACCESS_TOKEN_EXPIRE_TIME);
 
         return Jwts.builder()
-                .claim("user_id", user.getId())  // User의 ID를 포함
-                .claim("email", user.getEmail())  // User의 이메일 포함
+                .claim("account_id", account.getId())  // User의 ID를 포함
+                .claim("email", account.getEmail())  // User의 이메일 포함
                 .setIssuedAt(Date.from(ZonedDateTime.now().toInstant()))
                 .setExpiration(expiredAt)
                 .signWith(key, SignatureAlgorithm.HS256)
                 .compact();
     }
 
-    public String generateRefreshToken(User user) {
+    public String generateRefreshToken(Account account) {
         Date expiredAt = new Date(System.currentTimeMillis() + REFRESH_TOKEN_EXPIRE_TIME);
         return Jwts.builder()
-                .claim("user_id", user.getId())  // User의 ID를 포함
-                .claim("email", user.getEmail())  // User의 이메일 포함
+                .claim("account_id", account.getId())  // User의 ID를 포함
+                .claim("email", account.getEmail())  // User의 이메일 포함
                 .setIssuedAt(Date.from(ZonedDateTime.now().toInstant()))
                 .setExpiration(expiredAt)
                 .signWith(key, SignatureAlgorithm.HS256)
@@ -67,8 +67,8 @@ public class JwtProvider {
     /**
      * JWT 토큰에서 User ID 추출
      */
-    public Long getUserId(String token) {
-        return parseClaims(token).get("user_id", Long.class);
+    public Long getAccountId(String token) {
+        return parseClaims(token).get("account_id", Long.class);
     }
 
     /**
@@ -107,7 +107,7 @@ public class JwtProvider {
         Claims claims = parseClaims(token);
 
         // JWT에서 클레임을 가져옵니다.
-        Long userId = claims.get("user_id", Long.class);
+        Long accountId = claims.get("account_id", Long.class);
         String email = claims.get("email", String.class);
 
         // 사용자 정보 기반으로 Authentication 객체 생성

--- a/src/main/java/the_monitor/infrastructure/persistence/JpaAccountRepository.java
+++ b/src/main/java/the_monitor/infrastructure/persistence/JpaAccountRepository.java
@@ -2,8 +2,8 @@ package the_monitor.infrastructure.persistence;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
-import the_monitor.domain.model.User;
+import the_monitor.domain.model.Account;
 
 @Repository
-public interface JpaUserRepository extends JpaRepository<User, Long> {
+public interface JpaAccountRepository extends JpaRepository<Account, Long> {
 }

--- a/src/main/java/the_monitor/infrastructure/security/SecurityConfig.java
+++ b/src/main/java/the_monitor/infrastructure/security/SecurityConfig.java
@@ -65,6 +65,7 @@ public class SecurityConfig {
                         authorize.requestMatchers(CorsUtils::isPreFlightRequest).permitAll()
                                 // 특정 경로에 대한 인증 여부는 JwtAuthenticationFilter에서 처리
                                 .anyRequest().authenticated())  // 나머지 요청은 인증 필요
+//                                .anyRequest().permitAll())
                 .exceptionHandling(handler ->
                         handler.authenticationEntryPoint(jwtAuthenticationEntryPoint)
                                 .accessDeniedHandler(jwtAccessDeniedHandler))

--- a/src/main/java/the_monitor/presentation/AccountController.java
+++ b/src/main/java/the_monitor/presentation/AccountController.java
@@ -30,11 +30,13 @@ public class AccountController {
         accountService.verifyEmail(certifiedKey, response);
 
     }
-
-    @GetMapping("/sendVerificationEmail")
-    public ApiResponse<String> sendVerificationEmail(@RequestParam("email") String email) {
-        return ApiResponse.onSuccess(accountService.sendVerificationEmail(email));
-    }
+//
+//    @GetMapping("/sendVerificationEmail")
+//    public ApiResponse<String> sendVerificationEmail(@RequestParam("email") String email) {
+//
+//        return ApiResponse.onSuccess(accountService.sendVerificationEmail(email));
+//
+//    }
 
 
 

--- a/src/main/java/the_monitor/presentation/AccountController.java
+++ b/src/main/java/the_monitor/presentation/AccountController.java
@@ -1,0 +1,25 @@
+package the_monitor.presentation;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import the_monitor.application.service.AccountService;
+import the_monitor.common.ApiResponse;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/accounts")
+public class AccountController {
+
+    private final AccountService accountService;
+
+    @PostMapping("/createAccount")
+    public ApiResponse<String> createAccount() {
+
+        return ApiResponse.onSuccess(accountService.createAccount());
+
+    }
+
+
+}

--- a/src/main/java/the_monitor/presentation/AccountController.java
+++ b/src/main/java/the_monitor/presentation/AccountController.java
@@ -1,14 +1,14 @@
 package the_monitor.presentation;
 
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import the_monitor.application.dto.request.AccountCreateRequest;
 import the_monitor.application.service.AccountService;
 import the_monitor.common.ApiResponse;
+
+import java.io.IOException;
 
 @RestController
 @RequiredArgsConstructor
@@ -22,6 +22,18 @@ public class AccountController {
 
         return ApiResponse.onSuccess(accountService.createAccount(request));
 
+    }
+
+    @GetMapping("/verify")
+    public void verifyEmail(@RequestParam("certifiedKey") String certifiedKey, HttpServletResponse response) throws IOException {
+
+        accountService.verifyEmail(certifiedKey, response);
+
+    }
+
+    @GetMapping("/sendVerificationEmail")
+    public ApiResponse<String> sendVerificationEmail(@RequestParam("email") String email) {
+        return ApiResponse.onSuccess(accountService.sendVerificationEmail(email));
     }
 
 

--- a/src/main/java/the_monitor/presentation/AccountController.java
+++ b/src/main/java/the_monitor/presentation/AccountController.java
@@ -1,9 +1,12 @@
 package the_monitor.presentation;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import the_monitor.application.dto.request.AccountCreateRequest;
 import the_monitor.application.service.AccountService;
 import the_monitor.common.ApiResponse;
 
@@ -15,11 +18,12 @@ public class AccountController {
     private final AccountService accountService;
 
     @PostMapping("/createAccount")
-    public ApiResponse<String> createAccount() {
+    public ApiResponse<String> createAccount(@RequestBody @Valid AccountCreateRequest request){
 
-        return ApiResponse.onSuccess(accountService.createAccount());
+        return ApiResponse.onSuccess(accountService.createAccount(request));
 
     }
+
 
 
 }


### PR DESCRIPTION
## 📌 요약

- 회원가입과 이메일 인증 로직 구현했습니다.

## 📝 상세 내용
<img width="1010" alt="image" src="https://github.com/user-attachments/assets/2d58989b-6a24-472b-9dfb-849153936286">

- STMP 방식으로 이메일을 전송했습니다.
<img width="531" alt="image" src="https://github.com/user-attachments/assets/e1c9ace9-54ba-4fd6-ad54-abdf9f2da709">
- 계정 생성 시, UUID로 인코딩된 emailCertificationKey가 저장되고, 사용자에게 mail을 전송합니다. mail에 CertificationKey를 담아서 보내면, 사용자가 **인증 완료** 버튼을 눌렀을 때, _/verify_로 요청이 갑니다.
<img width="719" alt="image" src="https://github.com/user-attachments/assets/79cac26c-d65c-421b-80fd-93ef76065a59">
- Certification을 통한 Account 인증을 실시합니다.

## 🗣️ 질문 및 이외 사항

-

### ☑️ 누구에게 리뷰를 요청할까요?
@JIHYUN2EE 

## ☑️ 이슈 번호
close #5 