### PR TITLE
[✨FEATURE] JWT Token Storage Method Update

### DIFF
--- a/src/main/java/the_monitor/application/service/AccountService.java
+++ b/src/main/java/the_monitor/application/service/AccountService.java
@@ -1,6 +1,7 @@
 package the_monitor.application.service;
 
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 import the_monitor.application.dto.request.*;
 import the_monitor.domain.model.Account;
 
@@ -9,13 +10,15 @@ import java.util.List;
 
 public interface AccountService {
 
+    Account findAccountById(Long id);
+
     String sendEmailConfirm(AccountEmailRequest request);
 
     String verifyCode(AccountEmailCertifyRequest request);
 
     String accountSignUp(AccountSignUpRequest request);
 
-    String accountSignIn(AccountSignInRequest request, HttpServletResponse response);
+    String accountSignIn(AccountSignInRequest request, HttpServletResponse response, HttpSession session);
 
     String checkEmail(String email);
 

--- a/src/main/java/the_monitor/application/serviceImpl/AccountServiceImpl.java
+++ b/src/main/java/the_monitor/application/serviceImpl/AccountServiceImpl.java
@@ -1,6 +1,7 @@
 package the_monitor.application.serviceImpl;
 
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -31,6 +32,13 @@ public class AccountServiceImpl implements AccountService {
     private final TemporaryPasswordGenerateService temporaryPasswordGenerateService;
 
     private final JwtProvider jwtProvider;
+
+    @Override
+    public Account findAccountById(Long id) {
+
+        return accountRepository.findById(id).orElseThrow(() -> new ApiException(ErrorStatus._ACCOUNT_NOT_FOUND));
+
+    }
 
     @Override
     public String sendEmailConfirm(AccountEmailRequest request) {
@@ -93,19 +101,22 @@ public class AccountServiceImpl implements AccountService {
     }
 
     @Override
-    public String accountSignIn(AccountSignInRequest request, HttpServletResponse response) {
+    public String accountSignIn(AccountSignInRequest request, HttpServletResponse response, HttpSession session) {
 
         Account account = accountRepository.findAccountByEmail(request.getEmail());
-
         if (account == null) throw new ApiException(ErrorStatus._ACCOUNT_NOT_FOUND);
+
         if (!account.getPassword().equals(request.getPassword())) throw new ApiException(ErrorStatus._WRONG_PASSWORD);
 
-        jwtProvider.setAddCookieToken(account, response);
+        // AccessToken 발급 및 응답 헤더에 추가
+        String accessToken = jwtProvider.generateAccessToken(account);
+        response.setHeader("Authorization", "Bearer " + accessToken);
+
+        // RefreshToken 발급 및 세션에 저장
+        jwtProvider.storeRefreshTokenInSession(account, session);
 
         return "로그인 성공";
-
     }
-
     @Override
     public String checkEmail(String email) {
 

--- a/src/main/java/the_monitor/infrastructure/jwt/JwtProvider.java
+++ b/src/main/java/the_monitor/infrastructure/jwt/JwtProvider.java
@@ -5,20 +5,16 @@ import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.SignatureAlgorithm;
-import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 import io.jsonwebtoken.security.SignatureException;
 import java.security.Key;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Date;
-
-import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 import the_monitor.common.ApiException;
@@ -32,88 +28,60 @@ public class JwtProvider {
     private final Long ACCESS_TOKEN_EXPIRE_TIME;
     private final Long REFRESH_TOKEN_EXPIRE_TIME;
 
-    // JWT Provider 생성자
     public JwtProvider(@Value("${jwt.secret_key}") String secretKey,
                        @Value("${jwt.access_token_expire}") Long accessTokenExpire,
                        @Value("${jwt.refresh_token_expire}") Long refreshTokenExpire) {
 
-        this.key = Keys.secretKeyFor(SignatureAlgorithm.HS256);  // 안전한 256비트 비밀 키 생성
+        this.key = Keys.secretKeyFor(SignatureAlgorithm.HS256);
         this.ACCESS_TOKEN_EXPIRE_TIME = accessTokenExpire;
         this.REFRESH_TOKEN_EXPIRE_TIME = refreshTokenExpire;
 
     }
 
-    public void setAddCookieToken(Account account, HttpServletResponse response) {
-
-        // AccessToken과 RefreshToken 생성
-        String accessToken = generateAccessToken(account);
-        String refreshToken = generateRefreshToken(account);
-
-        int accessTokenExpireTime = Math.toIntExact(ACCESS_TOKEN_EXPIRE_TIME / 1000);
-        int refreshTokenExpireTime = Math.toIntExact(REFRESH_TOKEN_EXPIRE_TIME / 1000);
-
-        // 쿠키에 AccessToken 저장
-        Cookie accessTokenCookie = new Cookie("accessToken", accessToken);
-        accessTokenCookie.setHttpOnly(true); // HttpOnly 설정
-        accessTokenCookie.setSecure(true);   // HTTPS에서만 전송
-        accessTokenCookie.setPath("/");      // 모든 경로에서 쿠키 접근 가능
-        accessTokenCookie.setMaxAge(accessTokenExpireTime); // 만료 시간 설정
-
-        // 쿠키에 RefreshToken 저장
-        Cookie refreshTokenCookie = new Cookie("refreshToken", refreshToken);
-        refreshTokenCookie.setHttpOnly(true);
-        refreshTokenCookie.setSecure(true);
-        refreshTokenCookie.setPath("/");
-        refreshTokenCookie.setMaxAge(refreshTokenExpireTime);
-
-        // 응답에 쿠키 추가
-        response.addCookie(accessTokenCookie);
-        response.addCookie(refreshTokenCookie);
-
-    }
-
-    /**
-     * JWT 토큰 생성 (회원가입 또는 로그인 후 호출)
-     */
     public String generateAccessToken(Account account) {
-
         Date expiredAt = new Date(System.currentTimeMillis() + ACCESS_TOKEN_EXPIRE_TIME);
-
         return Jwts.builder()
-                .claim("account_id", account.getId())  // User의 ID를 포함
-                .claim("email", account.getEmail())  // User의 이메일 포함
+                .claim("account_id", account.getId())
+                .claim("email", account.getEmail())
                 .setIssuedAt(Date.from(ZonedDateTime.now().toInstant()))
                 .setExpiration(expiredAt)
                 .signWith(key, SignatureAlgorithm.HS256)
                 .compact();
-
     }
 
     public String generateRefreshToken(Account account) {
-
         Date expiredAt = new Date(System.currentTimeMillis() + REFRESH_TOKEN_EXPIRE_TIME);
         return Jwts.builder()
-                .claim("account_id", account.getId())  // User의 ID를 포함
-                .claim("email", account.getEmail())  // User의 이메일 포함
+                .claim("account_id", account.getId())
+                .claim("email", account.getEmail())
                 .setIssuedAt(Date.from(ZonedDateTime.now().toInstant()))
                 .setExpiration(expiredAt)
                 .signWith(key, SignatureAlgorithm.HS256)
                 .compact();
-
     }
 
-    /**
-     * JWT 토큰에서 User ID 추출
-     */
     public Long getAccountId(String token) {
-        return parseClaims(token).get("account_id", Long.class);
+        Claims claims = getClaimsFromToken(token);
+        return claims.get("account_id", Long.class);
     }
 
-    /**
-     * JWT 토큰에서 Claims(토큰 정보)를 파싱
-     */
-    public Claims parseClaims(String token) {
+    public void storeRefreshTokenInSession(Account account, HttpSession session) {
+        String refreshToken = generateRefreshToken(account);
+        session.setAttribute("refreshToken", refreshToken);
+    }
 
+    public String validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return "VALID";
+        } catch (ExpiredJwtException e) {
+            return "EXPIRED";
+        } catch (SignatureException | MalformedJwtException e) {
+            return "INVALID";
+        }
+    }
+
+    public Claims getClaimsFromToken(String token) {
         try {
             return Jwts.parserBuilder()
                     .setSigningKey(key)
@@ -123,62 +91,14 @@ public class JwtProvider {
         } catch (ExpiredJwtException e) {
             throw new ApiException(ErrorStatus._JWT_EXPIRED);
         }
-
     }
 
-    /**
-     * JWT 토큰 유효성 검증
-     */
-    public String validateToken(String token) {
-
-        try {
-            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
-            return "VALID";
-        } catch (ExpiredJwtException e) {
-            return "EXPIRED";
-        } catch (SignatureException | MalformedJwtException e) {
-            return "INVALID";
-        }
-
-    }
-
-    /**
-     * JWT 토큰을 기반으로 Authentication 객체 생성 (User 정보 포함)
-     */
-    public Authentication getAuthentication(String token) {
-
-        Claims claims = parseClaims(token);
-
-        // JWT에서 클레임을 가져옵니다.
-        Long accountId = claims.get("account_id", Long.class);
+    public Authentication getAuthenticationFromToken(String token) {
+        Claims claims = getClaimsFromToken(token);
         String email = claims.get("email", String.class);
 
-        // 사용자 정보 기반으로 Authentication 객체 생성
         UserDetails userDetails = new org.springframework.security.core.userdetails.User(email, "", new ArrayList<>());
         return new UsernamePasswordAuthenticationToken(userDetails, token, userDetails.getAuthorities());
-
-    }
-
-    /**
-     * SecurityContext에 인증 객체 설정
-     */
-    private void setContextHolder(Authentication authentication) {
-
-        SecurityContextHolder.getContext().setAuthentication(authentication);
-
-    }
-
-    /**
-     * JWT 토큰의 만료 시간을 가져옵니다.
-     */
-    public Long getExpiration(String token) {
-
-        Date expiration = Jwts.parserBuilder().setSigningKey(key)
-                .build().parseClaimsJws(token).getBody().getExpiration();
-
-        long now = new Date().getTime();
-        return expiration.getTime() - now;
-
     }
 
 }

--- a/src/main/java/the_monitor/infrastructure/security/SecurityConfig.java
+++ b/src/main/java/the_monitor/infrastructure/security/SecurityConfig.java
@@ -74,10 +74,10 @@ public class SecurityConfig {
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .csrf(AbstractHttpConfigurer::disable)
                 .cors(withDefaults())  // CORS 설정 적용
-                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.ALWAYS)) // 세션 사용 방식
                 .authorizeHttpRequests(authorize -> authorize
-                        .requestMatchers(PUBLIC_URLS).permitAll()  // 배열로 관리되는 공개 URL 패턴
-                        .anyRequest().authenticated()  // 나머지 모든 요청은 인증 필요
+                        .requestMatchers(PUBLIC_URLS).permitAll()  // 공개 URL 허용
+                        .anyRequest().authenticated()  // 나머지 요청은 인증 필요
                 )
                 .exceptionHandling(handler ->
                         handler.authenticationEntryPoint(jwtAuthenticationEntryPoint)
@@ -86,6 +86,7 @@ public class SecurityConfig {
                 .addFilterBefore(jwtExceptionFilter, JwtAuthenticationFilter.class);
 
         return http.build();
+
     }
 
 //    @Bean

--- a/src/main/java/the_monitor/presentation/AccountController.java
+++ b/src/main/java/the_monitor/presentation/AccountController.java
@@ -2,6 +2,7 @@ package the_monitor.presentation;
 
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -44,9 +45,9 @@ public class AccountController {
 
     @Operation(summary = "로그인", description = "로그인을 진행합니다.")
     @PostMapping("/signIn")
-    public ApiResponse<String> Login(@RequestBody @Valid AccountSignInRequest request, HttpServletResponse response) {
+    public ApiResponse<String> Login(@RequestBody @Valid AccountSignInRequest request, HttpServletResponse response, HttpSession session) {
 
-        return ApiResponse.onSuccess(accountService.accountSignIn(request, response));
+        return ApiResponse.onSuccess(accountService.accountSignIn(request, response, session));
 
     }
 


### PR DESCRIPTION
## 📌 요약

- JWT 토큰 저장 방식을 기존의 쿠키에 저장하는 것에서, 세션에 저장하는 것으로 변경하였습니다.

## 📝 상세 내용
<img width="1037" alt="image" src="https://github.com/user-attachments/assets/cd5aa5cb-ac88-4a4f-94f3-fee09601ecee">
- 위의 예시와 같이, 사용자 인증 정보가 필요하다면 `Authentication authentication = SecurityContextHolder.getContext().getAuthentication();` 사용해서 인증 정보 추출하시면 됩니다.

- `JwtAuthenticationFilter`에서 accessToken 만료 시, refreshToken으로부터 새로운 token을 발급하여 헤더에 담는 로직을 포함하고 있으니, 따로 엔드포인트 추가하지 않아도 됩니다.

## 🗣️ 질문 및 이외 사항

-

### ☑️ 누구에게 리뷰를 요청할까요?


## ☑️ 이슈 번호
close #33 