### PR TITLE
Fix: account에 해당하는 Client를 반환하게 수정

### DIFF
--- a/src/main/java/the_monitor/application/serviceImpl/ClientServiceImpl.java
+++ b/src/main/java/the_monitor/application/serviceImpl/ClientServiceImpl.java
@@ -129,9 +129,11 @@ public class ClientServiceImpl implements ClientService {
 
     @Override
     public ClientGetResponse getClient(Long clientId){
+        Long accountId = getAccountIdFromJwt();
 
-        Client client = clientRepository.findById(clientId)
-                .orElseThrow(() -> new ApiException(ErrorStatus._CLIENT_NOT_FOUND));
+        // clientId와 accountId를 동시에 검증
+        Client client = clientRepository.findByIdAndAccountId(clientId, accountId)
+                .orElseThrow(() -> new ApiException(ErrorStatus._CLIENT_FORBIDDEN));
 
         // Client 객체를 ClientResponse로 변환
         return ClientGetResponse.builder()
@@ -186,9 +188,11 @@ public class ClientServiceImpl implements ClientService {
     @Override
     @Transactional
     public String updateClient(Long clientId, ClientUpdateRequest request, MultipartFile logo) {
-        // 1. 고객사 조회
-        Client client = clientRepository.findById(clientId)
-                .orElseThrow(() -> new IllegalArgumentException("Client not found with id: " + clientId));
+        Long accountId = getAccountIdFromJwt();
+
+        // clientId와 accountId를 동시에 검증
+        Client client = clientRepository.findByIdAndAccountId(clientId, accountId)
+                .orElseThrow(() -> new ApiException(ErrorStatus._CLIENT_FORBIDDEN));
 
         String logoPath;
         logoPath = (logo != null) ? s3Service.uploadFile(logo) : defaultLogoUrl;

--- a/src/main/java/the_monitor/application/serviceImpl/EmailServiceImpl.java
+++ b/src/main/java/the_monitor/application/serviceImpl/EmailServiceImpl.java
@@ -91,8 +91,8 @@ public class EmailServiceImpl implements EmailService {
         CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
         Long accountId = userDetails.getAccountId();
 
-        Client client = clientRepository.findById(clientId)
-                .orElseThrow(() -> new ApiException(ErrorStatus._CLIENT_NOT_FOUND));
+        Client client = clientRepository.findByIdAndAccountId(clientId, accountId)
+                .orElseThrow(() -> new ApiException(ErrorStatus._CLIENT_FORBIDDEN));
 
         List<String> recipients = clientMailRecipientRepository.findAllByClient(client)
                 .stream()
@@ -123,8 +123,8 @@ public class EmailServiceImpl implements EmailService {
         CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
         Long accountId = userDetails.getAccountId();
 
-        Client client = clientRepository.findById(clientId)
-                .orElseThrow(() -> new ApiException(ErrorStatus._CLIENT_NOT_FOUND));
+        Client client = clientRepository.findByIdAndAccountId(clientId, accountId)
+                .orElseThrow(() -> new ApiException(ErrorStatus._CLIENT_FORBIDDEN));
 
         clientMailRecipientRepository.deleteAllByClient(client);
         clientMailCCRepository.deleteAllByClient(client);

--- a/src/main/java/the_monitor/application/serviceImpl/KeywordServiceImpl.java
+++ b/src/main/java/the_monitor/application/serviceImpl/KeywordServiceImpl.java
@@ -55,10 +55,11 @@ public class KeywordServiceImpl implements KeywordService {
 
         Map<CategoryType, List<String>> keywordsByCategory = keywordUpdateRequest.getKeywordsByCategory();
 
-        Long accountId = getAccountIdFromAuthentication();
+        Long accountId = getAccountIdFromAuthentication(); // JWT에서 accountId 추출
 
-        // 클라이언트 확인
-        Client client = findClientById(clientId);
+        // accountId와 clientId를 함께 검증
+        Client client = clientRepository.findByIdAndAccountId(clientId, accountId)
+                .orElseThrow(() -> new ApiException(ErrorStatus._CLIENT_FORBIDDEN));
 
         // 기존 키워드 삭제
         keywordRepository.deleteAllByClientId(clientId);

--- a/src/main/java/the_monitor/domain/repository/ClientRepository.java
+++ b/src/main/java/the_monitor/domain/repository/ClientRepository.java
@@ -6,8 +6,12 @@ import the_monitor.domain.model.Account;
 import the_monitor.domain.model.Client;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ClientRepository extends JpaRepository<Client, Long> {
     List<Client> findAllByAccountId(@Param("accountId") Long accountId);
 
-    List<Client> findByAccountAndNameContainingIgnoreCase(Account account, String name);}
+    List<Client> findByAccountAndNameContainingIgnoreCase(Account account, String name);
+
+    Optional<Client> findByIdAndAccountId(@Param("clientId") Long clientId, @Param("accountId") Long accountId);
+}


### PR DESCRIPTION
## 📌 요약

- Clientid로 고객사 전보 반환 / 이메일 조회 / 이메일 수정 / 고객사 정보 수정 / 키워드 업데이트 부문 수정했습니다. 

## 📝 상세 내용

-

## 🗣️ 질문 및 이외 사항

-

### ☑️ 누구에게 리뷰를 요청할까요?
@L-U-Ready 
## ☑️ 이슈 번호
close #138 